### PR TITLE
BugFix: Add missing semicolon.

### DIFF
--- a/autoload/cfparser.vim
+++ b/autoload/cfparser.vim
@@ -177,7 +177,7 @@ endfunction
 
 "}}}
 function! cfparser#CFTestAll() "{{{
-    echo system(printf("g++ %s -o /tmp/cfparser_exec
+    echo system(printf("g++ %s -o /tmp/cfparser_exec;
                         \cnt=0;
                         \for i in `ls %s/*.in | sed 's/.in//'`; do
                         \   let cnt++;


### PR DESCRIPTION
I don't know about BASH but that semicolon is needed in ZSH.

And it shouldn't break anything in other environments.