### PR TITLE
Fix: use UNKNOWN as verdict if absent

### DIFF
--- a/autoload/cfparser.vim
+++ b/autoload/cfparser.vim
@@ -170,7 +170,7 @@ function! cfparser#CFLastSubmissions(...) "{{{
     else
         let result = cf_response_json.result
         for sub in result
-            echom printf("%d%s - %s - %s - Last Test: %d - %.3fMB - %dms", sub.problem.contestId, sub.problem.index, sub.problem.name, sub.verdict, sub.passedTestCount, sub.memoryConsumedBytes / 1000000.0, sub.timeConsumedMillis)
+            echom printf("%d%s - %s - %s - Last Test: %d - %.3fMB - %dms", sub.problem.contestId, sub.problem.index, sub.problem.name, get(sub, 'verdict', 'UNKNOWN'), sub.passedTestCount, sub.memoryConsumedBytes / 1000000.0, sub.timeConsumedMillis)
         endfor
     endif
 endfunction


### PR DESCRIPTION
The Codeforces API doesn't guarantee, that each Submission comes with a `verdict` entry. E.g. it is missing, when the submission is currently is `In Queue`. Then the dict `sub` cannot access the field `verdict` and you receive a long error message. 

This fixes the problem by using `"UNKNOWN"` as default value for `verdict`.