### PR TITLE
Fixes sed substituation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can setup some variables at your .vimrc:
 function! cfparser#CFTestAll()
     echo system(printf("g++ %s -o /tmp/cfparser_exec;
                         \cnt=0;
-                        \for i in `ls %s/*.in | sed 's/\\.in//'`; do
+                        \for i in `ls %s/*.in | sed 's/\\.in$//'`; do
                         \   let cnt++;
                         \   echo \"\nTEST $cnt\";
                         \   /tmp/cfparser_exec < $i.in | diff -y - $i.out;

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can setup some variables at your .vimrc:
 function! cfparser#CFTestAll()
     echo system(printf("g++ %s -o /tmp/cfparser_exec;
                         \cnt=0;
-                        \for i in `ls %s/*.in | sed 's/.in//'`; do
+                        \for i in `ls %s/*.in | sed 's/\\.in//'`; do
                         \   let cnt++;
                         \   echo \"\nTEST $cnt\";
                         \   /tmp/cfparser_exec < $i.in | diff -y - $i.out;

--- a/autoload/cfparser.vim
+++ b/autoload/cfparser.vim
@@ -179,7 +179,7 @@ endfunction
 function! cfparser#CFTestAll() "{{{
     echo system(printf("g++ %s -o /tmp/cfparser_exec;
                         \cnt=0;
-                        \for i in `ls %s/*.in | sed 's/\\.in//'`; do
+                        \for i in `ls %s/*.in | sed 's/\\.in$//'`; do
                         \   let cnt++;
                         \   echo \"\nTEST $cnt\";
                         \   /tmp/cfparser_exec < $i.in | diff -y - $i.out;

--- a/autoload/cfparser.vim
+++ b/autoload/cfparser.vim
@@ -179,7 +179,7 @@ endfunction
 function! cfparser#CFTestAll() "{{{
     echo system(printf("g++ %s -o /tmp/cfparser_exec;
                         \cnt=0;
-                        \for i in `ls %s/*.in | sed 's/.in//'`; do
+                        \for i in `ls %s/*.in | sed 's/\\.in//'`; do
                         \   let cnt++;
                         \   echo \"\nTEST $cnt\";
                         \   /tmp/cfparser_exec < $i.in | diff -y - $i.out;


### PR DESCRIPTION
One more small bug that I found. 
Substitutions with `sed` as in `sed 's/.in//'` use regex by default. Therefore a path `~/YinYang/123A/0.in` gets substituted to `~/Yang/123A/0.in` instead of `~/YinYang/123A/0`. 

I escaping the point and added a $ at the end to prevent this. 