### PR TITLE
input passwd secretly

### DIFF
--- a/autoload/cfparser.vim
+++ b/autoload/cfparser.vim
@@ -83,7 +83,7 @@ endfunction
 "}}}
 function! cfparser#CFLogin() "{{{
     let s:cf_uname = input('username: ')
-    let s:cf_passwd = input('password: ')
+    let s:cf_passwd = inputsecret('password: ')
     let remember = input('remember? [Y/n] ')
     if remember ==? "n"
         let s:cf_remember = 1


### PR DESCRIPTION
While inputting password, general `input()` function shows what I type, which is a problem. `inputsecret()` function will show asterisk (*) instead of character.