### PR TITLE
change name of input field to "handleOrEmail"

### DIFF
--- a/autoload/cfparser.vim
+++ b/autoload/cfparser.vim
@@ -93,7 +93,7 @@ function! cfparser#CFLogin() "{{{
 
     let cf_response = system(printf("curl --silent --cookie-jar %s '%s://%s/enter'", g:cf_cookies_file, s:cf_proto, s:cf_host))
     let csrf_token = cfparser#CFGetToken(cf_response)
-    let cf_response = system(printf("curl --location --silent --cookie-jar %s --cookie %s --data 'action=enter&handle=%s&remember=%s&csrf_token=%s' --data-urlencode 'password=%s' '%s://%s/enter'", g:cf_cookies_file, g:cf_cookies_file, s:cf_uname, s:cf_remember, csrf_token, s:cf_passwd, s:cf_proto, s:cf_host))
+    let cf_response = system(printf("curl --location --silent --cookie-jar %s --cookie %s --data 'action=enter&handleOrEmail=%s&remember=%s&csrf_token=%s' --data-urlencode 'password=%s' '%s://%s/enter'", g:cf_cookies_file, g:cf_cookies_file, s:cf_uname, s:cf_remember, csrf_token, s:cf_passwd, s:cf_proto, s:cf_host))
     echon "\r\r"
     if empty(matchstr(cf_response, '"error for__password"'))
         echom "login: ok"


### PR DESCRIPTION
Codeforces recently changed the name of a input field of the login page from 

    <input id="handle" style="width: 15em;" name="handle" value=""/>
to:

    <input id="handleOrEmail" style="width: 15em;" name="handleOrEmail" value=""/>

Therefore it is now impossible to submit using the plugin.
This pull-request changes the parameter in the curl call accordingly and fixes the problem.