### PR TITLE
Add support for problems named with letter+number

### DIFF
--- a/autoload/cfparser.vim
+++ b/autoload/cfparser.vim
@@ -1,7 +1,7 @@
 " Variables "{{{
 let s:cf_host = 'codeforces.com'
 let s:cf_proto = 'http'
-let s:cf_path_regexp = '\([0-9]\+\)\/\?\([a-zA-Z]\)\/\?[^/.]*\(\.[^.]\+\)$'
+let s:cf_path_regexp = '\([0-9]\+\)\/\?\([a-zA-Z][0-9]*\)\/\?[^/.]*\(\.[^.]\+\)$'
 
 "}}}
 


### PR DESCRIPTION
Some problems on CF are not numbered A, B, C, ..., but A1, A2, A3, B1, ...
Like the contest [958](http://codeforces.com/contest/958) or the contest [690](http://codeforces.com/contest/690).
This commit adds support for these problems.
