### PR TITLE
fixed setting the remember option

### DIFF
--- a/autoload/cfparser.vim
+++ b/autoload/cfparser.vim
@@ -85,7 +85,7 @@ function! cfparser#CFLogin() "{{{
     let s:cf_uname = input('username: ')
     let s:cf_passwd = inputsecret('password: ')
     let remember = input('remember? [Y/n] ')
-    if remember ==? "n"
+    if remember ==? "Y"
         let s:cf_remember = 1
     else
         let s:cf_remember = 0


### PR DESCRIPTION
This should fix the problem I had in #13. Answering `remember (Y/n)` with `Y` actually didn't remember the password.

I think the confusion happened with the vimscript operator `==?`. It means compare the values **case-insensitive**, but can be easily interpreted with "not equal".