### PR TITLE
Remove empty lines from beginning of input/output

### DIFF
--- a/autoload/cfparser.vim
+++ b/autoload/cfparser.vim
@@ -27,8 +27,8 @@ endfunction
 
 "}}}
 function! cfparser#CFParseTests(data) "{{{
-    let input_regex = '<div class=\"input\">.\{-}<pre>\(.\{-}\)</pre></div>'
-    let output_regex = '<div class=\"output\">.\{-}<pre>\(.\{-}\)</pre></div>'
+    let input_regex = '<div class=\"input\">.\{-}<pre>\n*\(.\{-}\)</pre></div>'
+    let output_regex = '<div class=\"output\">.\{-}<pre>\n*\(.\{-}\)</pre></div>'
     let ret = []
     let from = 0
     while !empty(matchstr(a:data, input_regex, from))


### PR DESCRIPTION
Since a few weeks (or months?) Codeforces starts all (or some?) input/output fields with an empty line.
This results in .in and .out files with a leading empty line, which makes comparing the output and expected output harder.

This pull request removes leading empty lines from the beginning of each input/output field, if there are any.